### PR TITLE
Add Rust CI workflow

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,41 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    
+    - name: Cache cargo dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+    
+    - name: Check formatting
+      run: cargo fmt --all -- --check
+    
+    - name: Run tests
+      run: cargo test


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run `cargo test` and `cargo fmt --check`
- Workflow triggers on push to main and pull requests to main
- Includes Rust toolchain setup with rustfmt component and cargo dependency caching

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Check that cargo fmt formatting checks work correctly
- [ ] Ensure cargo test runs and passes

🤖 Generated with [Claude Code](https://claude.ai/code)